### PR TITLE
🛠️ Fixed FAQ, Guide & Legalnotice Layout Directions

### DIFF
--- a/app/faq/page.tsx
+++ b/app/faq/page.tsx
@@ -17,7 +17,7 @@ export default function Page() {
         className="w-3/4 mx-auto flex flex-col items-center justify-center gap-8"
         style={
           i18n.language === "ar"
-            ? { direction: "rtl", textAlign: "right" }
+            ? { direction: "rtl", textAlign: "left" }
             : { direction: "ltr", textAlign: "left" }
         }
       >
@@ -26,7 +26,10 @@ export default function Page() {
           <h1 className="font-bold text-gray-800 md:text-4xl text-2xl">
             FAQ - Inscription en ligne
           </h1>
-          <div className="flex flex-col gap-8">
+          <div 
+            className="flex flex-col gap-8"
+            dir="ltr"
+          >
             {faq.map((item, index) => (
               <div key={index} className="flex flex-col gap-2">
                 <h2 className="font-bold text-gray-800 md:text-xl text-lg">

--- a/app/guide/page.tsx
+++ b/app/guide/page.tsx
@@ -18,12 +18,16 @@ export default function Page() {
         className="w-3/4 mx-auto flex flex-col items-center justify-center gap-8"
         style={
           i18n.language === "ar"
-            ? { direction: "rtl", textAlign: "right" }
+            ? { direction: "rtl", textAlign: "left" }
             : { direction: "ltr", textAlign: "left" }
         }
       >
         {/* Header */}
-        <div className="flex flex-col gap-12 py-2">
+        <div 
+          className="flex flex-col gap-12 py-2"
+          dir="ltr"
+          //in case the hooks not making effects, the dir attribute will be used
+        >
           <h1 className="font-bold text-gray-800 md:text-4xl text-2xl">
             Guide - Inscription en ligne
           </h1>

--- a/app/legalnotice/page.tsx
+++ b/app/legalnotice/page.tsx
@@ -18,7 +18,7 @@ export default function Page() {
         className="w-3/4 mx-auto flex flex-col items-center justify-center gap-8"
         style={
           i18n.language === "ar"
-            ? { direction: "rtl", textAlign: "right" }
+            ? { direction: "rtl", textAlign: "left" }
             : { direction: "ltr", textAlign: "left" }
         }
       >

--- a/components/CustomButtons/CustomEmailButton.tsx
+++ b/components/CustomButtons/CustomEmailButton.tsx
@@ -16,7 +16,11 @@ const CustomEmailButton = () => {
         height={24}
         className="object-contain"
       ></Image>
-      <p className="flex-grow">inscription@mesrs.tn</p>
+      <p 
+        className="flex-grow text-base md:text-sm"
+      >
+        inscription@mesrs.tn
+      </p>
     </Link>
   );
 };


### PR DESCRIPTION
The `FAQ, Guide and LegalNotice` content was originally declared as a **constants** in a local file located at `constants\index.ts`, not within the **Arabic JSON file** found in `locales\ar.json`. 

To address this, I've updated the FAQ page to use LTR layout direction **always**.

I have 3 solutions for this issue, the first solution is used in this PR for temporary changes while the other two solutions are outlined below.

### Second solution

* If you'd like to include Arabic translations in the JSON file for these paths: `/faq`, `/guide` or `/legalnotice`, please leave a comment, and I'll make the necessary changes. 

* This includes translating each question and its corresponding response, as well as implementing the use of i18n hooks, same implementation for the `/guide` or `/legalnotice` paths.

### Third solution

* To hide the language bar in the mentioned paths, without making any modifications....

<br>

# Before
![image](https://github.com/NidhalChelhi/inscription.tn/assets/108496649/57bbd53a-09d9-4db5-a8bc-43d73d78efba)

# After
![image](https://github.com/NidhalChelhi/inscription.tn/assets/108496649/967334e9-d7a0-4e16-96c2-93df066635c3)

